### PR TITLE
Add CIMDraw to the LFE landscape

### DIFF
--- a/hosted_logos/cimdraw-text.svg
+++ b/hosted_logos/cimdraw-text.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xml:space="preserve"
+   style="enable-background:new 0 0 288 242.79;"
+   viewBox="0 0 288 242.79"
+   y="0px"
+   x="0px"
+   id="Layer_1"
+   version="1.1"><metadata
+   id="metadata1027"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs1025" />
+
+<g
+   id="text1031"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:25.16267014px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.62906247"
+   aria-label="CIMDraw"><path
+     id="path1056"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.16267014px;font-family:Arimo;-inkscape-font-specification:'Arimo Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;stroke-width:0.62906247"
+     d="m 99.400151,127.45222 q 3.280489,0 4.558279,-3.29278 l 3.15762,1.19179 q -1.01978,2.50644 -2.9979,3.73509 -1.96583,1.21636 -4.717999,1.21636 -4.177396,0 -6.462677,-2.35901 -2.272996,-2.37128 -2.272996,-6.6224 0,-4.2634 2.199277,-6.54868 2.199276,-2.28528 6.376673,-2.28528 3.047042,0 4.963732,1.22864 1.91669,1.21636 2.69073,3.58765 l -3.19448,0.87234 q -0.40545,-1.30237 -1.59724,-2.06413 -1.1795,-0.77404 -2.789024,-0.77404 -2.457292,0 -3.735084,1.52352 -1.265505,1.52352 -1.265505,4.45998 0,2.98561 1.302365,4.55828 1.314651,1.57267 3.784229,1.57267 z" /><path
+     id="path1058"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.16267014px;font-family:Arimo;-inkscape-font-specification:'Arimo Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;stroke-width:0.62906247"
+     d="m 109.48734,130.05695 v -17.31163 h 3.6245 v 17.31163 z" /><path
+     id="path1060"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.16267014px;font-family:Arimo;-inkscape-font-specification:'Arimo Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;stroke-width:0.62906247"
+     d="m 130.85349,130.05695 v -10.49264 q 0,-0.35631 0,-0.71262 0.0123,-0.3563 0.12286,-3.05932 -0.87233,3.30505 -1.29007,4.60742 l -3.12077,9.65716 h -2.58015 l -3.12076,-9.65716 -1.31465,-4.60742 q 0.14743,2.85045 0.14743,3.77194 v 10.49264 h -3.21905 v -17.31163 h 4.85315 l 3.09619,9.68173 0.2703,0.93378 0.58975,2.32214 0.77405,-2.77674 3.18219,-10.16091 h 4.82858 v 17.31163 z" /><path
+     id="path1062"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.16267014px;font-family:Arimo;-inkscape-font-specification:'Arimo Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;stroke-width:0.62906247"
+     d="m 152.87083,121.27213 q 0,2.67845 -1.05664,4.68114 -1.04435,1.9904 -2.97332,3.04704 -1.91669,1.05664 -4.39856,1.05664 h -7.00328 v -17.31163 h 6.2661 q 4.37398,0 6.76984,2.21157 2.39586,2.19927 2.39586,6.31524 z m -3.64908,0 q 0,-2.78903 -1.44981,-4.25112 -1.4498,-1.47437 -4.14053,-1.47437 h -2.56787 v 11.70899 h 3.07161 q 2.33443,0 3.71051,-1.60952 1.37609,-1.60953 1.37609,-4.37398 z" /><path
+     id="path1064"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.16267014px;font-family:Arimo;-inkscape-font-specification:'Arimo Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;stroke-width:0.62906247"
+     d="m 155.68442,130.05695 v -10.17319 q 0,-1.0935 -0.0369,-1.8184 -0.0246,-0.73719 -0.0614,-1.30236 h 3.29277 q 0.0369,0.22115 0.0983,1.35151 0.0614,1.11806 0.0614,1.48666 h 0.0491 q 0.50375,-1.40066 0.89691,-1.96584 0.39317,-0.57746 0.93378,-0.84776 0.5406,-0.28259 1.35151,-0.28259 0.66346,0 1.06892,0.1843 v 2.88732 q -0.83548,-0.1843 -1.47438,-0.1843 -1.29008,0 -2.01498,1.04435 -0.71261,1.04435 -0.71261,3.09619 v 6.52411 z" /><path
+     id="path1066"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.16267014px;font-family:Arimo;-inkscape-font-specification:'Arimo Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;stroke-width:0.62906247"
+     d="m 168.54835,130.30268 q -1.92897,0 -3.01018,-1.04435 -1.08121,-1.05664 -1.08121,-2.96104 0,-2.06413 1.33922,-3.14533 1.35151,-1.08121 3.9071,-1.10579 l 2.86274,-0.0491 v -0.67576 q 0,-1.30236 -0.4546,-1.92897 -0.45459,-0.6389 -1.48666,-0.6389 -0.95834,0 -1.41294,0.44232 -0.44231,0.43002 -0.55289,1.43751 l -3.59993,-0.17201 q 0.33173,-1.94126 1.76925,-2.93646 1.4498,-1.00749 3.94395,-1.00749 2.51872,0 3.88252,1.24093 1.3638,1.24093 1.3638,3.52621 v 4.84087 q 0,1.11807 0.24573,1.54809 0.25801,0.41774 0.84776,0.41774 0.39317,0 0.76176,-0.0737 v 1.86755 q -0.30716,0.0737 -0.55289,0.13515 -0.24573,0.0614 -0.49145,0.0983 -0.24573,0.0369 -0.52832,0.0614 -0.2703,0.0246 -0.6389,0.0246 -1.30236,0 -1.92897,-0.63889 -0.61433,-0.6389 -0.73719,-1.87983 h -0.0737 q -1.4498,2.61702 -4.37398,2.61702 z m 4.01767,-6.40125 -1.76925,0.0246 q -1.20407,0.0491 -1.70781,0.2703 -0.50375,0.20887 -0.77405,0.65119 -0.25802,0.44231 -0.25802,1.1795 0,0.94605 0.43003,1.41294 0.44231,0.4546 1.16721,0.4546 0.81091,0 1.47438,-0.44231 0.67575,-0.44232 1.05663,-1.21636 0.38088,-0.78634 0.38088,-1.65868 z" /><path
+     id="path1068"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:25.16267014px;font-family:Arimo;-inkscape-font-specification:'Arimo Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;stroke-width:0.62906247"
+     d="m 193.84617,130.05695 h -3.64908 l -2.11327,-8.10907 q -0.14743,-0.55289 -0.57746,-2.72759 l -0.6389,2.75217 -2.13784,8.08449 h -3.64908 L 177.64033,116.763 h 3.24363 l 2.18699,10.1609 0.17201,-0.9092 0.30716,-1.43752 2.0887,-7.81418 h 3.69822 l 2.03955,7.81418 q 0.17201,0.6389 0.50375,2.34672 l 0.34402,-1.62181 1.91669,-8.53909 h 3.19448 z" /></g></svg>

--- a/landscape.yml
+++ b/landscape.yml
@@ -443,6 +443,13 @@ landscape:
             twitter: https://twitter.com/ENTSO_E
             crunchbase: https://www.crunchbase.com/organization/entso-e
           - item:
+            name: CIMDraw
+            description:  CIMDraw is a WebApp to view IEC CIM (CGMES) files
+            homepage_url: https://danielepala.github.io/CIMDraw
+            logo: cimdraw-text.svg
+            repo_url: https://github.com/danielePala/CIMDraw
+            crunchbase: https://www.crunchbase.com/organization/ricerca-sul-sistema-energetico-rse-s-p-a
+          - item:
             name: CIMSpy
             description: CIM/RDF/XML file browser, editor, and validator.
             homepage_url: http://www.powerinfo.us/CIMSpyEE.html


### PR DESCRIPTION
CIMDraw is a neat and modern interface to view IEC CIM (CGMES) files. This
addition was checked with the CIMDraw project in advance:
https://github.com/danielePala/CIMDraw/issues/11

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>