### PR TITLE
Fix typos in landscape.yml descriptions

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -47,11 +47,11 @@ landscape:
         name: Photovoltaics and Solar Energy
         items:
           - item:
-            name: A Global Inventory of Commerical-, Industrial-, and Utility-Scale Photovoltaic Solar Generating Units
-            description: Used to produce a global inventory of utility-scale solar photvoltaic generating station.
+            name: A Global Inventory of Commercial-, Industrial-, and Utility-Scale Photovoltaic Solar Generating Units
+            description: Used to produce a global inventory of utility-scale solar photovoltaic generating station.
             homepage_url: https://github.com/Lkruitwagen/solar-pv-global-inventory
             repo_url: https://github.com/Lkruitwagen/solar-pv-global-inventory
-            logo: A Global Inventory of Commerical-, Industrial-, and Utility-Scale Photovoltaic Solar Generating Units.svg
+            logo: A Global Inventory of Commercial-, Industrial-, and Utility-Scale Photovoltaic Solar Generating Units.svg
             extra:
               refs: ',https://zenodo.org/record/5005868,https://zenodo.org/record/5005868'
             organization:


### PR DESCRIPTION
## What changed
Fixed minor typos in landscape.yml descriptions.

## Changes made
- Corrected "Commerical" to "Commercial"
- Corrected "photvoltaic" to "photovoltaic"

## Why
Improves readability and documentation accuracy.