### PR TITLE
Fix broken URLs in landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -10312,7 +10312,7 @@ landscape:
           - item:
             name: openair
             description: An R package developed for the purpose of analyzing air quality data — or more generally atmospheric composition data.
-            homepage_url: http://davidcarslaw.github.io/openair/
+            homepage_url: https://openair-project.github.io/openair/
             repo_url: https://github.com/davidcarslaw/openair
             logo: openair.svg
             crunchbase: https://www.crunchbase.com/organization/university-of-york
@@ -11642,7 +11642,7 @@ landscape:
           - item:
             name: AgroMo
             description: An Integrated Assessment and Modelling software that integrates a crop, biogeochemical and a agro-economical model.
-            homepage_url: http://agromo.atk.hu/EN/index.html
+            homepage_url: https://atk.hun-ren.hu/agromo/EN/index.html
             repo_url: https://github.com/hollorol/AgroMo
             logo: AgroMo.svg
             extra:


### PR DESCRIPTION
## What changed
Updated broken and outdated URLs in `landscape.yml`.

## Changes made
- Replaced outdated `openair` project URL with the current active project site
- Updated AgroMo project URL to the current maintained HTTPS domain

## Why
Improves accessibility and prevents broken external references.